### PR TITLE
chore(ovos-skill-days-in-history): allow ovos-workshop<9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 wikipedia==1.4.0
-ovos-workshop>=3.1.0,<8.0.0
+ovos-workshop>=3.1.0,<9.0.0
 ovos-date-parser>=0.0.3


### PR DESCRIPTION
Update ovos-workshop dependency upper bound to <9.0.0