### PR TITLE
fix(da-DK): restore {day} placeholder, add missing date-specific intent templates

### DIFF
--- a/locale/da-DK/births_in_history.intent
+++ b/locale/da-DK/births_in_history.intent
@@ -1,1 +1,6 @@
-hvem blev født i dag i historien
+hvem blev født (i dag|denne dag|denne dato|på denne dag|på denne dato) [i historien]
+hvem blev født [den] {date} [i historien]
+(hvilke|hvem) [berømte|kendte|historiske] (personer|skikkelser) blev født (i dag|denne dag|denne dato|på denne dag|på denne dato) [i historien]
+(hvilke|hvem) [berømte|kendte|historiske] (personer|skikkelser) blev født [den] {date} [i historien]
+[berømte|kendte] fødsler (i dag|denne dag|denne dato|på denne dag|på denne dato) i historien
+[berømte|kendte] fødsler [den] {date} i historien

--- a/locale/da-DK/deaths_in_history.intent
+++ b/locale/da-DK/deaths_in_history.intent
@@ -1,1 +1,6 @@
-hvem døde i dag i historien
+hvem døde (i dag|denne dag|denne dato|på denne dag|på denne dato) [i historien]
+hvem døde [den] {date} [i historien]
+(hvilke|hvem) [berømte|kendte|historiske] (personer|skikkelser) døde (i dag|denne dag|denne dato|på denne dag|på denne dato) [i historien]
+(hvilke|hvem) [berømte|kendte|historiske] (personer|skikkelser) døde [den] {date} [i historien]
+[berømte|kendte] dødsfald (i dag|denne dag|denne dato|på denne dag|på denne dato) i historien
+[berømte|kendte] dødsfald [den] {date} i historien

--- a/locale/da-DK/searching.dialog
+++ b/locale/da-DK/searching.dialog
@@ -1,2 +1,2 @@
-Jeg tjekker Wikipedia for begivenheder i historien den {dag}
-Lige et øjeblik mens jeg finder historiske begivenheder på {dag}
+Jeg tjekker Wikipedia for begivenheder i historien den {day}
+Lige et øjeblik mens jeg finder historiske begivenheder på {day}


### PR DESCRIPTION
Found via ovos-localize validation while doing a general da-DK translation review.

## searching.dialog
Both lines had translated `{day}` to `{dag}` - must match the English source exactly since the skill substitutes by that key.

## births_in_history.intent / deaths_in_history.intent
Only had a single "today" template each (1 line vs the sources 6), missing every `{date}`-parameterized variant entirely - meaning it was impossible to ask about a specific date in Danish, only "today". Added the missing templates, translated to natural Danish and matching the sources Padatious alternation structure ((required|alternatives), [optional|alternatives]).